### PR TITLE
Add DomainOrBundleKey transformer for site/app lookup key resolution

### DIFF
--- a/java/src/main/java/com/amazon/demanddriventrafficevaluator/modelfeature/FeatureTransformerName.java
+++ b/java/src/main/java/com/amazon/demanddriventrafficevaluator/modelfeature/FeatureTransformerName.java
@@ -13,7 +13,8 @@ public enum FeatureTransformerName {
     ConcatenateByPair,
     GetFirstNotEmpty,
     Exists,
-    IncludeDefaultValue;
+    IncludeDefaultValue,
+    DomainOrBundleKey;
 
     @JsonCreator
     public static FeatureTransformerName fromString(String value) {

--- a/java/src/main/java/com/amazon/demanddriventrafficevaluator/modelfeature/transformer/DomainOrBundleKey.java
+++ b/java/src/main/java/com/amazon/demanddriventrafficevaluator/modelfeature/transformer/DomainOrBundleKey.java
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.demanddriventrafficevaluator.modelfeature.transformer;
+
+import com.amazon.demanddriventrafficevaluator.modelfeature.ModelFeature;
+import com.amazon.demanddriventrafficevaluator.util.DomainNameUtil;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A transformer that resolves the single lookup key for a request, choosing between the app
+ * bundle and the web registered domain.
+ * <p>
+ * This transformer owns the full selection-and-normalization chain, so it should be the only
+ * transformer on its feature (do not pair it with {@code GetFirstNotEmpty}). It expects the
+ * feature's extracted values to arrive positionally, in the order the feature's {@code fields}
+ * are configured:
+ * <pre>
+ *   "fields": ["$.app.bundle", "$.site.page", "$.site.domain"]
+ *   "transformation": ["DomainOrBundleKey"]
+ * </pre>
+ * so {@code values = [bundle, page, domain]}.
+ * </p>
+ * <p>
+ * Resolution priority:
+ * <ol>
+ *   <li>If {@code app.bundle} is non-empty, use it as-is (app traffic).</li>
+ *   <li>Else if {@code site.page} yields a registered domain (Public Suffix List), use that.</li>
+ *   <li>Else if {@code site.domain} yields a registered domain, use that.</li>
+ *   <li>Else fall back to the raw {@code site.domain} if non-empty, otherwise the raw
+ *       {@code site.page} (or empty string if neither is present).</li>
+ * </ol>
+ * </p>
+ */
+public class DomainOrBundleKey implements Transformer {
+
+    public DomainOrBundleKey() {
+    }
+
+    @Override
+    public ModelFeature transform(ModelFeature modelFeature) {
+        List<String> values = modelFeature.getValues();
+        String bundle = valueAt(values, 0);
+        String page = valueAt(values, 1);
+        String domain = valueAt(values, 2);
+
+        String key = resolveKey(bundle, page, domain);
+
+        return ModelFeature.builder()
+                .configuration(modelFeature.getConfiguration())
+                .values(List.of(key))
+                .build();
+    }
+
+    private String resolveKey(String bundle, String page, String domain) {
+        // 1. App bundle wins, used verbatim.
+        if (StringUtils.isNotEmpty(bundle)) {
+            return bundle;
+        }
+
+        // 2 & 3. Registered domain from site.page, falling back to site.domain (page-first).
+        String registeredDomain = DomainNameUtil.resolveRegisteredDomain(page, domain);
+        if (registeredDomain != null) {
+            return registeredDomain;
+        }
+
+        // 4. Nothing extractable: raw site.domain, else raw site.page, else empty.
+        if (StringUtils.isNotEmpty(domain)) {
+            return domain;
+        }
+        if (StringUtils.isNotEmpty(page)) {
+            return page;
+        }
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Returns the value at {@code index}, or empty string if the list is too short or the entry
+     * is null. {@code JsonExtractor} may emit "null" for a present-but-null field; treat that as
+     * empty too so it does not become a lookup key.
+     */
+    private String valueAt(List<String> values, int index) {
+        if (values == null || index >= values.size()) {
+            return StringUtils.EMPTY;
+        }
+        String value = values.get(index);
+        if (value == null || "null".equals(value)) {
+            return StringUtils.EMPTY;
+        }
+        return value;
+    }
+}

--- a/java/src/main/java/com/amazon/demanddriventrafficevaluator/util/DomainNameUtil.java
+++ b/java/src/main/java/com/amazon/demanddriventrafficevaluator/util/DomainNameUtil.java
@@ -1,0 +1,179 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.demanddriventrafficevaluator.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.InternetDomainName;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility for deriving the model lookup key (a "registered domain") from an
+ * OpenRTB site URL, using Guava's {@link InternetDomainName} (Public Suffix List).
+ */
+public final class DomainNameUtil {
+
+    // Matches www-like prefixes on a hostname: www., ww., www2., w3., etc.
+    private static final Pattern REGEX_WWW_PREFIX = Pattern.compile("^w+\\d*\\.");
+
+    // Matches www-like subdomain labels: www, ww, www2, w3, etc.
+    private static final Pattern REGEX_WWW09 = Pattern.compile("^w+\\d*$");
+
+    // Matches IP-like strings (IPv4 dotted notation and IPv6 colon notation).
+    private static final Pattern REGEX_IPADDR = Pattern.compile("^[0-9:\\.]+$");
+
+    // Domain-specific overrides for how many subdomain levels to include in the registered
+    // domain. e.g. "wordpress.com" -> 2 keeps up to 2 levels beyond the registered domain
+    // (myblog.wordpress.com instead of just wordpress.com).
+    private static final Map<String, Integer> MAX_SITENAME_PARTS = ImmutableMap.<String, Integer>builder()
+            .put("go.com", 2)
+            .put("wordpress.com", 2)
+            .put("blogspot.com", 2)
+            .put("yahoo.com", 1)
+            .put("msn.com", 1)
+            .put("aol.com", 1)
+            .put("google.com", 1)
+            .put("cnn.com", 1)
+            .build();
+    private static final int DEFAULT_MAX_SITENAME_PARTS = 0;
+
+    private DomainNameUtil() {
+        // Utility class — prevent instantiation
+    }
+
+    /**
+     * Derives the registered domain (model lookup key) from a site URL or bare domain.
+     * <p>
+     * Tries the supplied {@code page} first (the full page URL), falling back to {@code domain}.
+     * Normalizes the hostname, decomposes it against the Public Suffix List, and builds the
+     * registered domain with any well-known multi-level overrides applied.
+     * </p>
+     *
+     * @param page   value of OpenRTB {@code site.page} (may be null/blank/invalid)
+     * @param domain value of OpenRTB {@code site.domain} (fallback; may be null/blank/invalid)
+     * @return the registered domain (e.g. "example.com", "myblog.wordpress.com"), or null if
+     *         neither input yields a valid domain under a recognized public suffix
+     */
+    public static String resolveRegisteredDomain(String page, String domain) {
+        // Priority 1: site.page
+        String hostname = extractHostname(page);
+        String[] parts = hostname != null ? getDomainNameParts(hostname) : null;
+
+        // Priority 2: site.domain (fallback if page absent or invalid)
+        if (parts == null) {
+            hostname = extractHostname(domain);
+            parts = hostname != null ? getDomainNameParts(hostname) : null;
+        }
+
+        if (parts == null || parts.length < 2) {
+            return null;
+        }
+        return buildRegisteredDomain(parts);
+    }
+
+    /**
+     * Extracts and normalizes a hostname from a domain, URL, or URL-like string.
+     * Strips scheme, lowercases, rejects IP addresses, and removes www-like prefixes.
+     *
+     * @param input a domain name, URL, or URL-like string; may be null
+     * @return normalized hostname, or null for blank input, IPs, or unparseable strings
+     */
+    static String extractHostname(String input) {
+        if (StringUtils.isBlank(input)) {
+            return null;
+        }
+
+        // java.net.URL requires a scheme
+        String urlStr = input.trim();
+        if (!urlStr.startsWith("http")) {
+            if (urlStr.startsWith("//")) {
+                urlStr = "http://" + urlStr.substring(2);
+            } else {
+                urlStr = "http://" + urlStr;
+            }
+        }
+
+        try {
+            URL url = new URL(urlStr);
+            String host = url.getHost();
+            if (StringUtils.isBlank(host)) {
+                return null;
+            }
+            host = host.toLowerCase();
+            if (REGEX_IPADDR.matcher(host).matches()) {
+                return null;
+            }
+            return stripWwwPrefix(host);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    private static String stripWwwPrefix(String host) {
+        Matcher wwwMatcher = REGEX_WWW_PREFIX.matcher(host);
+        if (wwwMatcher.find()) {
+            return host.substring(wwwMatcher.end());
+        }
+        return host;
+    }
+
+    /**
+     * Decomposes a domain name relative to its public suffix.
+     * Returns [suffix, registeredLabel, subdomain1, subdomain2, ...] (subdomains outermost-first),
+     * e.g. "news.example.co.uk" -> ["co.uk", "example", "news"]; or null if the domain is invalid
+     * or not under a recognized public suffix.
+     */
+    static String[] getDomainNameParts(String domainName) {
+        if (domainName == null || !InternetDomainName.isValid(domainName)) {
+            return null;
+        }
+
+        InternetDomainName domain = InternetDomainName.from(domainName);
+        if (!domain.isUnderPublicSuffix()) {
+            return null;
+        }
+
+        List<String> domainParts = new ArrayList<>();
+        InternetDomainName publicSuffix = domain.publicSuffix();
+        domainParts.add(publicSuffix.toString());
+
+        int totalDomainPartsLen = domain.parts().size();
+        domainParts.addAll(domain.parts().subList(0, totalDomainPartsLen - publicSuffix.parts().size()).reverse());
+
+        return domainParts.toArray(new String[0]);
+    }
+
+    /**
+     * Builds the registered domain from PSL parts, applying MAX_SITENAME_PARTS overrides for
+     * well-known multi-level domains and skipping www-like outermost labels.
+     */
+    private static String buildRegisteredDomain(String[] parts) {
+        String registeredDomain = parts[1] + "." + parts[0];
+
+        Integer nPartOverride = MAX_SITENAME_PARTS.get(registeredDomain);
+        int nParts = nPartOverride != null ? nPartOverride : DEFAULT_MAX_SITENAME_PARTS;
+        if (nParts > 0) {
+            StringBuilder extendedDomain = new StringBuilder();
+            for (int i = Math.min(nParts + 1, parts.length - 1); i > 1; i--) {
+                // Skip www-like labels at the outermost position
+                if (i == parts.length - 1 && REGEX_WWW09.matcher(parts[i]).matches()) {
+                    continue;
+                }
+                extendedDomain.append(parts[i]).append(".");
+            }
+            extendedDomain.append(registeredDomain);
+            registeredDomain = extendedDomain.toString();
+        }
+
+        return registeredDomain;
+    }
+}

--- a/java/src/main/resources/META-INF/services/com.amazon.demanddriventrafficevaluator.modelfeature.transformer.Transformer
+++ b/java/src/main/resources/META-INF/services/com.amazon.demanddriventrafficevaluator.modelfeature.transformer.Transformer
@@ -6,4 +6,5 @@ com.amazon.demanddriventrafficevaluator.modelfeature.transformer.ConcatenateByPa
 com.amazon.demanddriventrafficevaluator.modelfeature.transformer.Exists
 com.amazon.demanddriventrafficevaluator.modelfeature.transformer.GetFirstNotEmpty
 com.amazon.demanddriventrafficevaluator.modelfeature.transformer.IncludeDefaultValue
+com.amazon.demanddriventrafficevaluator.modelfeature.transformer.DomainOrBundleKey
 

--- a/java/src/test/java/com/amazon/demanddriventrafficevaluator/modelfeature/FeatureTransformerNameTest.java
+++ b/java/src/test/java/com/amazon/demanddriventrafficevaluator/modelfeature/FeatureTransformerNameTest.java
@@ -21,14 +21,15 @@ class FeatureTransformerNameTest {
 
     @Test
     void testEnumValues() {
-        assertEquals(5, FeatureTransformerName.values().length);
+        assertEquals(6, FeatureTransformerName.values().length);
         assertArrayEquals(
                 new FeatureTransformerName[]{
                         FeatureTransformerName.ApplyMappings,
                         FeatureTransformerName.ConcatenateByPair,
                         FeatureTransformerName.GetFirstNotEmpty,
                         FeatureTransformerName.Exists,
-                        FeatureTransformerName.IncludeDefaultValue
+                        FeatureTransformerName.IncludeDefaultValue,
+                        FeatureTransformerName.DomainOrBundleKey
                 },
                 FeatureTransformerName.values()
         );
@@ -64,7 +65,7 @@ class FeatureTransformerNameTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"ApplyMappings", "ConcatenateByPair", "GetFirstNotEmpty", "Exists", "IncludeDefaultValue"})
+    @ValueSource(strings = {"ApplyMappings", "ConcatenateByPair", "GetFirstNotEmpty", "Exists", "IncludeDefaultValue", "DomainOrBundleKey"})
     void testJsonDeserialization(String name) throws JsonProcessingException {
         FeatureTransformerName transformerName = objectMapper.readValue("\"" + name + "\"", FeatureTransformerName.class);
         assertEquals(FeatureTransformerName.valueOf(name), transformerName);

--- a/java/src/test/java/com/amazon/demanddriventrafficevaluator/modelfeature/transformer/DomainOrBundleKeyTest.java
+++ b/java/src/test/java/com/amazon/demanddriventrafficevaluator/modelfeature/transformer/DomainOrBundleKeyTest.java
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.demanddriventrafficevaluator.modelfeature.transformer;
+
+import com.amazon.demanddriventrafficevaluator.modelfeature.ModelFeature;
+import com.amazon.demanddriventrafficevaluator.repository.entity.FeatureConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DomainOrBundleKeyTest {
+
+    private DomainOrBundleKey transformer;
+    private FeatureConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new DomainOrBundleKey();
+        configuration = new FeatureConfiguration();
+    }
+
+    /** values are positional: [bundle, page, domain]. */
+    private ModelFeature feature(String bundle, String page, String domain) {
+        return ModelFeature.builder()
+                .configuration(configuration)
+                .values(Arrays.asList(bundle, page, domain))
+                .build();
+    }
+
+    private String key(String bundle, String page, String domain) {
+        return transformer.transform(feature(bundle, page, domain)).getValues().get(0);
+    }
+
+    @Test
+    void step1_appBundleWins_evenWhenSitePresent() {
+        assertEquals("com.fitnow.loseit",
+                key("com.fitnow.loseit", "https://www.accuweather.com/x", "www.accuweather.com"));
+    }
+
+    @Test
+    void step2_registeredDomainFromPage() {
+        assertEquals("accuweather.com",
+                key("", "https://www.accuweather.com/en/us/x", "ignored-because-page-extracts.com"));
+    }
+
+    @Test
+    void step3_fallsBackToDomainWhenPageNotExtractable() {
+        // page is non-empty but not a real domain -> must fall through to site.domain
+        assertEquals("accuweather.com",
+                key("", "android-app://com.foo.bar", "www.accuweather.com"));
+    }
+
+    @Test
+    void step4_rawDomainWhenNeitherExtracts() {
+        // neither page nor domain is a valid registered domain -> raw site.domain
+        assertEquals("not-a-real-tld-xyz",
+                key("", "also-bad", "not-a-real-tld-xyz"));
+    }
+
+    @Test
+    void step4_rawPageWhenDomainEmptyAndNeitherExtracts() {
+        assertEquals("bad-page-value",
+                key("", "bad-page-value", ""));
+    }
+
+    @Test
+    void step4_emptyWhenNothingPresent() {
+        assertEquals("", key("", "", ""));
+    }
+
+    @Test
+    void nullBundleTreatedAsAbsent() {
+        // JsonExtractor emits "null" for present-but-null fields
+        assertEquals("accuweather.com",
+                key("null", "https://www.accuweather.com/x", ""));
+    }
+
+    @Test
+    void handlesShortValuesList() {
+        // Only bundle provided (list length 1) — should not throw, returns bundle.
+        ModelFeature f = ModelFeature.builder()
+                .configuration(configuration)
+                .values(List.of("com.example.app"))
+                .build();
+        assertEquals("com.example.app", transformer.transform(f).getValues().get(0));
+    }
+
+    @Test
+    void handlesEmptyValuesList() {
+        ModelFeature f = ModelFeature.builder()
+                .configuration(configuration)
+                .values(Collections.emptyList())
+                .build();
+        assertEquals("", transformer.transform(f).getValues().get(0));
+    }
+
+    @Test
+    void preservesConfiguration() {
+        ModelFeature result = transformer.transform(feature("", "https://www.example.com", ""));
+        assertEquals(configuration, result.getConfiguration());
+    }
+}

--- a/java/src/test/java/com/amazon/demanddriventrafficevaluator/util/DomainNameUtilTest.java
+++ b/java/src/test/java/com/amazon/demanddriventrafficevaluator/util/DomainNameUtilTest.java
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.demanddriventrafficevaluator.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DomainNameUtilTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            // page input, expected registered domain
+            "https://www.example.com/page,         example.com",
+            "http://example.com,                   example.com",
+            "example.com,                          example.com",
+            "//www.example.com,                    example.com",
+            "https://news.example.co.uk/article,   example.co.uk",
+            "https://www2.example.com,             example.com",
+            "https://myblog.wordpress.com/post,    myblog.wordpress.com",
+            "EXAMPLE.COM,                          example.com",
+            "example.com/path?q=1&x=2,             example.com",
+    })
+    void resolveRegisteredDomain_fromPage(String page, String expected) {
+        assertEquals(expected, DomainNameUtil.resolveRegisteredDomain(page, null));
+    }
+
+    @Test
+    void resolveRegisteredDomain_fallsBackToDomainWhenPageInvalid() {
+        assertEquals("example.com", DomainNameUtil.resolveRegisteredDomain("", "www.example.com"));
+        assertEquals("example.com", DomainNameUtil.resolveRegisteredDomain(null, "example.com"));
+    }
+
+    @Test
+    void resolveRegisteredDomain_pageWins_overDomain() {
+        assertEquals("page-domain.com",
+                DomainNameUtil.resolveRegisteredDomain("https://page-domain.com/x", "fallback.com"));
+    }
+
+    @Test
+    void resolveRegisteredDomain_rejectsIpAddresses() {
+        assertNull(DomainNameUtil.resolveRegisteredDomain("http://192.168.1.1/x", null));
+    }
+
+    @Test
+    void resolveRegisteredDomain_rejectsGarbageAndBlanks() {
+        assertNull(DomainNameUtil.resolveRegisteredDomain(null, null));
+        assertNull(DomainNameUtil.resolveRegisteredDomain("", ""));
+        assertNull(DomainNameUtil.resolveRegisteredDomain("android-app", null));
+        assertNull(DomainNameUtil.resolveRegisteredDomain("no-public-suffix-here", null));
+    }
+}


### PR DESCRIPTION
## What
  Adds a `DomainOrBundleKey` feature transformer that resolves a single lookup
  key from an OpenRTB request, for use as a bloom-filter key.

  Resolution priority:
  1. `app.bundle` (used as-is) — app traffic
  2. registered domain (Public Suffix List) from `site.page`
  3. registered domain from `site.domain`
  4. raw `site.domain`, else raw `site.page`, else empty string

  Also adds a `DomainNameUtil` helper that derives the registered domain via
  Guava's `InternetDomainName` (normalizes scheme/`www.`/casing, rejects IPs,
  applies well-known multi-level overrides).

  ## How it's wired
  - New transformer registered via the `Transformer` SPI file and the
    `FeatureTransformerName` enum (value `DomainOrBundleKey`).
  - Configured on a feature whose `fields` are ordered
    `["$.app.bundle", "$.site.page", "$.site.domain"]`; it should be the only
    transformer on that feature.

  ## Testing
  - Unit tests for `DomainOrBundleKey` (all 4 resolution steps + edge cases)
    and `DomainNameUtil`.
  - Full suite passes locally: 536 tests, 0 failures.
  - Verified end-to-end against a running DTE instance: a request for
    `www.accuweather.com` normalizes to `accuweather.com` and matches a seeded
    bloom filter (hit), while a different domain misses.